### PR TITLE
chore(make): verify deps match lockfile before checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 .DEFAULT_GOAL := check
 
+.PHONY: deps-verify
+deps-verify:
+	npm ci --dry-run
+
 .PHONY: videos
 videos: videos/avsynctest-vga-1m.mp4 videos/avsynctest-hd1080-10m.mp4
 
@@ -15,15 +19,15 @@ resources/bin:
 	cp node_modules/ffmpeg-ffprobe-static/ffprobe $@ || cp node_modules/ffmpeg-ffprobe-static/ffprobe.exe $@
 
 .PHONY: lint
-lint:
+lint: deps-verify
 	npx eslint .
 
 .PHONY: typecheck
-typecheck:
+typecheck: deps-verify
 	npx tsc --noEmit
 
 .PHONY: test-prereqs
-test-prereqs: resources/bin videos/avsynctest-vga-1m.mp4
+test-prereqs: deps-verify resources/bin videos/avsynctest-vga-1m.mp4
 
 .PHONY: test
 test: test-prereqs
@@ -33,7 +37,7 @@ test: test-prereqs
 check: lint typecheck test
 
 .PHONY: e2e-build
-e2e-build:
+e2e-build: deps-verify
 	npx electron-forge package
 
 .PHONY: e2e


### PR DESCRIPTION
Add a deps-verify target that runs npm ci --dry-run and wire it into lint, typecheck, test, and e2e-build so make check/e2e fail fast when node_modules are out of sync with package-lock.json.

Made-with: Cursor
