### PR TITLE
chore(make): add dev target to start local app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,10 @@ test: deps test-prereqs
 .PHONY: check
 check: deps lint typecheck test
 
+.PHONY: dev
+dev: deps resources/bin
+	$(PNPM) start
+
 .PHONY: e2e-build
 e2e-build: deps
 	$(PNPM_EXEC) electron-forge package


### PR DESCRIPTION
Add a make dev target that installs dependencies, ensures ffmpeg/ffprobe binaries are copied into resources/bin, and starts the Electron Forge dev process via pnpm.

Made-with: Cursor
