### PR TITLE
feat: five-point frame slider with left/mid/right limits

### DIFF
--- a/e2e/happy-path.pw.spec.ts
+++ b/e2e/happy-path.pw.spec.ts
@@ -1,14 +1,22 @@
-import { test, expect } from './fixtures';
+import { expect, test } from './fixtures';
 
 test.describe('Happy path', () => {
-  test('range selection updates command and can copy', async ({ page, videoVga1mPath }) => {
+  test('range selection updates command and can copy', async ({
+    page,
+    videoVga1mPath,
+  }) => {
     await expect(page.locator('#root')).toBeVisible();
 
-    await page.getByTestId('e2e-video-file-input').setInputFiles(videoVga1mPath);
+    await page
+      .getByTestId('e2e-video-file-input')
+      .setInputFiles(videoVga1mPath);
     await expect(page.getByTestId('e2e-start-end-selector')).toBeVisible();
     await expect(page.getByTestId('e2e-command-example')).toBeVisible();
 
-    const commandTextarea = page.getByTestId('e2e-ffmpeg-command').locator('textarea').first();
+    const commandTextarea = page
+      .getByTestId('e2e-ffmpeg-command')
+      .locator('textarea')
+      .first();
 
     const commandBefore = await commandTextarea.inputValue();
     await expect(commandTextarea).toContainText('ffmpeg');
@@ -19,7 +27,9 @@ test.describe('Happy path', () => {
     await expect(commandTextarea).toContainText('-c copy');
 
     // Move the end slider thumb a bit to force command change.
-    const endThumb = page.locator('[data-testid="e2e-range-slider"] input').nth(1);
+    const endThumb = page
+      .locator('[data-testid="e2e-range-slider"] .MuiSlider-thumb')
+      .nth(3);
     await endThumb.focus();
     for (let i = 0; i < 3; i++) {
       await page.keyboard.press('ArrowLeft');
@@ -30,7 +40,9 @@ test.describe('Happy path', () => {
 
     // Deterministic clipboard assertion: override writeText and capture the last written text.
     await page.evaluate(() => {
-      const windowAny = window as unknown as { __e2e_lastClipboardWrite: string | null };
+      const windowAny = window as unknown as {
+        __e2e_lastClipboardWrite: string | null;
+      };
       windowAny.__e2e_lastClipboardWrite = null;
 
       const clipboard = navigator.clipboard as unknown as {
@@ -49,10 +61,11 @@ test.describe('Happy path', () => {
     );
 
     const copied = await page.evaluate(() => {
-      const windowAny = window as unknown as { __e2e_lastClipboardWrite: string | null };
+      const windowAny = window as unknown as {
+        __e2e_lastClipboardWrite: string | null;
+      };
       return windowAny.__e2e_lastClipboardWrite;
     });
     expect(copied).toBe(commandAfter);
   });
 });
-

--- a/e2e/slider-limits.pw.spec.ts
+++ b/e2e/slider-limits.pw.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from './fixtures';
+
+test.describe('Range slider limits', () => {
+  test('right limit thumb can be adjusted with keyboard', async ({
+    page,
+    videoVga1mPath,
+  }) => {
+    await expect(page.locator('#root')).toBeVisible();
+
+    await page.getByTestId('e2e-video-file-input').setInputFiles(videoVga1mPath);
+    await expect(page.getByTestId('e2e-start-end-selector')).toBeVisible();
+    await expect(page.getByTestId('e2e-command-example')).toBeVisible();
+
+    const endFrame = page
+      .getByTestId('e2e-frame-view-end')
+      .getByTestId('e2e-frame-number');
+    const endBefore = await endFrame.textContent();
+
+    // Thumbs are ordered: leftLimit, start, midLimit, end, rightLimit
+    const rightLimitThumb = page
+      .locator('[data-testid="e2e-range-slider"] .MuiSlider-thumb')
+      .nth(4);
+    await rightLimitThumb.click();
+    for (let i = 0; i < 3; i++) {
+      await page.keyboard.press('ArrowLeft');
+    }
+
+    const endAfter = await endFrame.textContent();
+    expect(endAfter).not.toBe(endBefore);
+  });
+});

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,6 +19,8 @@ export default [{
         ".vite/**",
         "dist/**",
         "out/**",
+        "playwright-report/**",
+        "test-results/**",
     ],
 }, ...fixupConfigRules(compat.extends(
     "eslint:recommended",

--- a/src/renderer/components/StartEndSelector.tsx
+++ b/src/renderer/components/StartEndSelector.tsx
@@ -1,6 +1,8 @@
 import { css } from '@emotion/react';
-import { Slider } from '@mui/material';
-import { useContext } from 'react';
+import NavigationIcon from '@mui/icons-material/Navigation';
+import { Slider, SliderThumb } from '@mui/material';
+import { sliderClasses } from '@mui/material/Slider';
+import { forwardRef, useContext, type ReactNode } from 'react';
 import { frameNumberToTimecode } from '../../utils/frameNumberToTimecode';
 import { FrameView } from './FrameView';
 import {
@@ -8,6 +10,66 @@ import {
   FrameNumbersDispatchContext,
 } from './context-providers/FrameNumbersContextsProvider';
 import { VideoInfoContext } from './context-providers/VideoInfoContextsProvider';
+
+const RangeThumb = forwardRef<HTMLSpanElement, Record<string, unknown>>(
+  (props, ref) => {
+    const thumbProps = props as Record<string, unknown> & {
+      children?: ReactNode;
+      'data-index'?: number;
+    };
+
+    const dataIndex = Number(thumbProps['data-index']);
+    const limit = dataIndex === 0 || dataIndex === 2 || dataIndex === 4;
+
+    const { children, ...rest } = thumbProps;
+
+    if (limit) {
+      return (
+        <SliderThumb
+          {...rest}
+          ref={ref}
+          css={css({
+            boxShadow: 'none',
+            width: '30px',
+            height: '30px',
+            backgroundColor: 'transparent',
+            border: 'none',
+            borderRadius: 0,
+            // Keep MUI's centering transform and offset the marker from the rail.
+            transform: 'translate(-50%, -50%) translateY(-14px)',
+            '&::before': {
+              display: 'none',
+            },
+            '&:hover': {
+              boxShadow: 'none',
+            },
+            [`&.${sliderClasses.focusVisible}`]: {
+              boxShadow: 'none',
+            },
+            [`&.${sliderClasses.active}`]: {
+              boxShadow: 'none',
+            },
+          })}
+        >
+          {children}
+          <NavigationIcon
+            css={css({
+              display: 'block',
+              fontSize: 28,
+              transform: 'scaleY(-1)',
+            })}
+          />
+        </SliderThumb>
+      );
+    }
+
+    return (
+      <SliderThumb {...rest} ref={ref}>
+        {children}
+      </SliderThumb>
+    );
+  },
+);
 
 export const StartEndSelector = () => {
   const { frameCount, fps } = useContext(VideoInfoContext);
@@ -22,16 +84,49 @@ export const StartEndSelector = () => {
     dispatchFrameNumbers({ type: 'SET_END', end });
   };
 
-  const handleRangeChange = (event: Event, newValue: number[]) => {
-    const [start, end] = newValue;
-    setStart(start);
-    setEnd(end);
+  const handleRangeChange = (
+    _event: Event,
+    newValue: number | number[],
+    activeThumb: number,
+  ) => {
+    const points = Array.isArray(newValue)
+      ? newValue
+      : [
+          frameNumbers.leftLimit,
+          frameNumbers.start,
+          frameNumbers.midLimit,
+          frameNumbers.end,
+          frameNumbers.rightLimit,
+        ];
+
+    switch (activeThumb) {
+      case 0:
+        dispatchFrameNumbers({ type: 'SET_LEFT_LIMIT', leftLimit: points[0] });
+        return;
+      case 1:
+        dispatchFrameNumbers({ type: 'SET_START', start: points[1] });
+        return;
+      case 2:
+        dispatchFrameNumbers({ type: 'SET_MID_LIMIT', midLimit: points[2] });
+        return;
+      case 3:
+        dispatchFrameNumbers({ type: 'SET_END', end: points[3] });
+        return;
+      case 4:
+        dispatchFrameNumbers({
+          type: 'SET_RIGHT_LIMIT',
+          rightLimit: points[4],
+        });
+        return;
+      default:
+        return;
+    }
   };
 
   return (
     <div
       data-testid="e2e-start-end-selector"
-      css={css({ display: 'flex', flexDirection: 'column', gap: '8px' })}
+      css={css({ display: 'flex', flexDirection: 'column', gap: '16px' })}
     >
       <div
         css={css({
@@ -44,29 +139,36 @@ export const StartEndSelector = () => {
           testId="e2e-frame-view-start"
           frameNumber={frameNumbers.start}
           setFrameNumber={setStart}
-          frameNumberMin={0}
-          frameNumberMax={frameNumbers.end}
+          frameNumberMin={frameNumbers.leftLimit}
+          frameNumberMax={frameNumbers.midLimit}
           css={css({ flex: 1 })}
         />
         <FrameView
           testId="e2e-frame-view-end"
           frameNumber={frameNumbers.end}
           setFrameNumber={setEnd}
-          frameNumberMin={frameNumbers.start}
-          frameNumberMax={frameCount - 1}
+          frameNumberMin={frameNumbers.midLimit}
+          frameNumberMax={frameNumbers.rightLimit}
           css={css({ flex: 1 })}
         />
       </div>
-      <div css={css({ padding: '0px 16px' })}>
+      <div css={css({ padding: '8px 16px 0px 16px' })}>
         <Slider
           data-testid="e2e-range-slider"
-          value={[frameNumbers.start, frameNumbers.end]}
+          value={[
+            frameNumbers.leftLimit,
+            frameNumbers.start,
+            frameNumbers.midLimit,
+            frameNumbers.end,
+            frameNumbers.rightLimit,
+          ]}
           onChange={handleRangeChange}
           valueLabelDisplay="auto"
           valueLabelFormat={(value) => frameNumberToTimecode(value, fps)}
           min={0}
           max={frameCount - 1}
           disableSwap
+          slots={{ thumb: RangeThumb }}
         />
       </div>
     </div>

--- a/src/renderer/states/frameNumbers.test.ts
+++ b/src/renderer/states/frameNumbers.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from '@jest/globals';
+import { frameNumbersInitialState, frameNumbersReducer } from './frameNumbers';
+
+describe('frameNumbersReducer', () => {
+  describe('RESET', () => {
+    it('initializes to all zeros when frameCount is <= 0', () => {
+      const cases = [-1, 0];
+
+      for (const frameCount of cases) {
+        const state = frameNumbersReducer(frameNumbersInitialState, {
+          type: 'RESET',
+          frameCount,
+        });
+
+        expect(state).toEqual({
+          min: 0,
+          leftLimit: 0,
+          start: 0,
+          midLimit: 0,
+          end: 0,
+          rightLimit: 0,
+          max: 0,
+        });
+      }
+    });
+
+    it('initializes mid/end/right/max from max(0, frameCount - 1)', () => {
+      const cases: Array<{ frameCount: number; expected: typeof frameNumbersInitialState }> =
+        [
+          {
+            frameCount: 1,
+            expected: {
+              min: 0,
+              leftLimit: 0,
+              start: 0,
+              midLimit: 0,
+              end: 0,
+              rightLimit: 0,
+              max: 0,
+            },
+          },
+          {
+            frameCount: 2,
+            expected: {
+              min: 0,
+              leftLimit: 0,
+              start: 0,
+              midLimit: 0,
+              end: 1,
+              rightLimit: 1,
+              max: 1,
+            },
+          },
+          {
+            frameCount: 101,
+            expected: {
+              min: 0,
+              leftLimit: 0,
+              start: 0,
+              midLimit: 50,
+              end: 100,
+              rightLimit: 100,
+              max: 100,
+            },
+          },
+        ];
+
+      for (const { frameCount, expected } of cases) {
+        const state = frameNumbersReducer(frameNumbersInitialState, {
+          type: 'RESET',
+          frameCount,
+        });
+
+        expect(state).toEqual(expected);
+      }
+    });
+  });
+
+  it('SET_START does not move neighbors (clamps to limits)', () => {
+    const initial = frameNumbersReducer(frameNumbersInitialState, {
+      type: 'RESET',
+      frameCount: 101,
+    });
+
+    const next = frameNumbersReducer(initial, { type: 'SET_START', start: -10 });
+    expect(next.start).toBe(0);
+    expect(next.leftLimit).toBe(0);
+    expect(next.midLimit).toBe(50);
+  });
+
+  it('SET_LEFT_LIMIT does not move start (clamps to start)', () => {
+    const initial = frameNumbersReducer(frameNumbersInitialState, {
+      type: 'RESET',
+      frameCount: 101,
+    });
+
+    const next = frameNumbersReducer(initial, { type: 'SET_LEFT_LIMIT', leftLimit: 80 });
+    expect(next.leftLimit).toBe(0);
+    expect(next.start).toBe(0);
+  });
+});

--- a/src/renderer/states/frameNumbers.ts
+++ b/src/renderer/states/frameNumbers.ts
@@ -2,20 +2,29 @@ import { clamp } from '../../utils/clamp';
 
 export type FrameNumbersState = {
   min: number;
+  leftLimit: number;
   start: number;
+  midLimit: number;
   end: number;
+  rightLimit: number;
   max: number;
 };
 
 export type FrameNumbersAction =
   | { type: 'RESET'; frameCount: number }
+  | { type: 'SET_LEFT_LIMIT'; leftLimit: number }
   | { type: 'SET_START'; start: number }
-  | { type: 'SET_END'; end: number };
+  | { type: 'SET_MID_LIMIT'; midLimit: number }
+  | { type: 'SET_END'; end: number }
+  | { type: 'SET_RIGHT_LIMIT'; rightLimit: number };
 
 export const frameNumbersInitialState: FrameNumbersState = {
   min: 0,
+  leftLimit: 0,
   start: 0,
+  midLimit: 0,
   end: 0,
+  rightLimit: 0,
   max: 0,
 };
 
@@ -24,17 +33,44 @@ export const frameNumbersReducer = (
   action: FrameNumbersAction,
 ): FrameNumbersState => {
   switch (action.type) {
-    case 'RESET':
+    case 'RESET': {
+      const maxIndex = Math.max(0, action.frameCount - 1);
+
       return {
         min: 0,
+        leftLimit: 0,
         start: 0,
-        end: action.frameCount - 1,
-        max: action.frameCount - 1,
+        midLimit: Math.floor(maxIndex / 2),
+        end: maxIndex,
+        rightLimit: maxIndex,
+        max: maxIndex,
+      };
+    }
+    case 'SET_LEFT_LIMIT':
+      return {
+        ...state,
+        leftLimit: clamp(action.leftLimit, state.min, state.start),
       };
     case 'SET_START':
-      return { ...state, start: clamp(action.start, state.min, state.end) };
+      return {
+        ...state,
+        start: clamp(action.start, state.leftLimit, state.midLimit),
+      };
+    case 'SET_MID_LIMIT':
+      return {
+        ...state,
+        midLimit: clamp(action.midLimit, state.start, state.end),
+      };
     case 'SET_END':
-      return { ...state, end: clamp(action.end, state.start, state.max) };
+      return {
+        ...state,
+        end: clamp(action.end, state.midLimit, state.rightLimit),
+      };
+    case 'SET_RIGHT_LIMIT':
+      return {
+        ...state,
+        rightLimit: clamp(action.rightLimit, state.end, state.max),
+      };
     default:
       throw new Error('Unhandled action type');
   }


### PR DESCRIPTION
## Summary
- Extend frame state with `leftLimit`, `midLimit`, and `rightLimit` and clamp in the reducer.
- Replace the start/end slider with a five-thumb MUI `Slider`: limit positions use a marker `NavigationIcon`; `RangeThumb` forwards MUI `children` so hidden range inputs exist; start/end use default `SliderThumb` appearance.
- Add `frameNumbers` unit tests, update happy-path e2e thumb indices, add a limit-thumb keyboard e2e spec.
- **Chore (separate commit):** ignore `playwright-report/**` and `test-results/**` in ESLint so local `eslint` does not parse Playwright output.

## Test plan
- [ ] `make check`
- [ ] `make e2e` (or CI)


Made with [Cursor](https://cursor.com)