### PR TITLE
feat(renderer): persist copy codec and WSL when changing video

### DIFF
--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import { Alert, Button, CircularProgress, Tooltip } from '@mui/material';
 import type { ChangeEvent, DragEvent } from 'react';
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { CommandExample } from './components/CommandExample';
 import {
@@ -29,6 +29,9 @@ const Content = () => {
 
   const frameNumbers = useContext(FrameNumbersContext);
   const dispatchFrameNumbers = useContext(FrameNumbersDispatchContext);
+
+  const [copyCodec, setCopyCodec] = useState(false);
+  const [wsl, setWsl] = useState(false);
 
   const resetFrameNumbers = () => {
     dispatchFrameNumbers({
@@ -122,6 +125,10 @@ const Content = () => {
         <CommandExample
           startFrameNumber={frameNumbers.start}
           endFrameNumber={frameNumbers.end}
+          copyCodec={copyCodec}
+          onCopyCodecChange={setCopyCodec}
+          wsl={wsl}
+          onWslChange={setWsl}
         />
       )}
     </div>

--- a/src/renderer/components/CommandExample.tsx
+++ b/src/renderer/components/CommandExample.tsx
@@ -10,28 +10,35 @@ import { VideoInfoContext } from './context-providers/VideoInfoContextsProvider'
 export const CommandExample = (props: {
   startFrameNumber: number;
   endFrameNumber: number;
+  copyCodec: boolean;
+  onCopyCodecChange: (value: boolean) => void;
+  wsl: boolean;
+  onWslChange: (value: boolean) => void;
 }) => {
   const { filePath, fps } = useContext(VideoInfoContext);
-  const [copyCodec, setCopyCodec] = useState(false);
-  const [wsl, setWsl] = useState(false);
+  const {
+    startFrameNumber,
+    endFrameNumber,
+    copyCodec,
+    onCopyCodecChange,
+    wsl,
+    onWslChange,
+  } = props;
 
   const filePathConverted = wsl ? convertWinPathToWSL(filePath) : filePath;
 
   const command = [
     'ffmpeg',
     '-ss',
-    frameNumberToTimecode(props.startFrameNumber, fps),
+    frameNumberToTimecode(startFrameNumber, fps),
     '-i',
     `"${filePathConverted}"`,
     '-to',
-    frameNumberToTimecode(
-      props.endFrameNumber - props.startFrameNumber + 1,
-      fps,
-    ),
+    frameNumberToTimecode(endFrameNumber - startFrameNumber + 1, fps),
   ]
     .concat(copyCodec ? ['-c', 'copy'] : [])
     .concat([
-      `"${getOutPath(filePathConverted, props.startFrameNumber, props.endFrameNumber)}"`,
+      `"${getOutPath(filePathConverted, startFrameNumber, endFrameNumber)}"`,
     ])
     .join(' ');
 
@@ -88,7 +95,7 @@ export const CommandExample = (props: {
               inputProps={switchInputProps('e2e-copy-codec-switch')}
               checked={copyCodec}
               onChange={(event) => {
-                setCopyCodec(event.target.checked);
+                onCopyCodecChange(event.target.checked);
               }}
             />
           }
@@ -101,7 +108,7 @@ export const CommandExample = (props: {
                 inputProps={switchInputProps('e2e-wsl-switch')}
                 checked={wsl}
                 onChange={(event) => {
-                  setWsl(event.target.checked);
+                  onWslChange(event.target.checked);
                 }}
               />
             }


### PR DESCRIPTION
Move copyCodec and wsl state from CommandExample up to Content so it is not
reset when CommandExample unmounts during a new getVideoInfo fetch (fps and
frameCount become undefined until the next video loads). CommandExample now
takes these values and change handlers as props.

Co-authored-by: Cursor <cursoragent@cursor.com>
